### PR TITLE
feat: expand ai message width

### DIFF
--- a/components/chat/message.tsx
+++ b/components/chat/message.tsx
@@ -15,11 +15,13 @@ export function Message({
   isUser: boolean;
 }) {
   return (
-    <div className="flex flex-row gap-2 items-end">
+    <div className={cn("flex flex-row gap-2 items-end", !isUser && "w-full")}> 
       <div
         className={cn(
-          "flex w-max max-w-[75%] flex-col gap-2 rounded-lg px-3 py-2 text-sm",
-          isUser ? "bg-primary text-primary-foreground ml-auto" : "bg-muted",
+          "flex flex-col gap-2 rounded-lg px-3 py-2 text-sm",
+          isUser
+            ? "bg-primary text-primary-foreground ml-auto w-max max-w-[75%]"
+            : "bg-muted w-full",
         )}
       >
         {parts.map((part: UIMessage["parts"][number], i: number) => {


### PR DESCRIPTION
## Summary
- stretch AI messages to fill the chat container

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Module not found: Can't resolve 'react-markdown'; GET https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bca19e5b2c83249e459cc2f18d9149