### PR TITLE
Enable search sheet without current file and adjust sidebar button alignment

### DIFF
--- a/components/chat/message.tsx
+++ b/components/chat/message.tsx
@@ -15,13 +15,12 @@ export function Message({
   isUser: boolean;
 }) {
   return (
-    <div className={cn("flex flex-row gap-2 items-end", !isUser && "w-full")}> 
+    <div className={cn("flex flex-row gap-2 items-end", !isUser && "w-full")}>
       <div
         className={cn(
-          "flex flex-col gap-2 rounded-lg px-3 py-2 text-sm",
-          isUser
-            ? "bg-primary text-primary-foreground ml-auto w-max max-w-[75%]"
-            : "bg-muted w-full",
+          "flex flex-col gap-2 text-sm",
+          isUser &&
+            "rounded-lg px-3 py-2 bg-primary text-primary-foreground ml-auto w-max max-w-[75%]",
         )}
       >
         {parts.map((part: UIMessage["parts"][number], i: number) => {

--- a/components/chat/searchSheet.tsx
+++ b/components/chat/searchSheet.tsx
@@ -20,7 +20,6 @@ import {
 } from "@/components/ui/select";
 import { TelescopeIcon } from "lucide-react";
 import { Loader2Icon } from "lucide-react";
-import { useDashboardStore } from "@/store/dashboard";
 import { SearchIcon } from "lucide-react";
 import { useChatStore } from "@/store/chat";
 import { Message } from "./message";
@@ -30,7 +29,6 @@ import { models } from "@/store/chat";
 import { useMemo } from "react";
 
 export function SearchSheet() {
-  const { currentFile } = useDashboardStore();
   const {
     input,
     setInput,
@@ -52,7 +50,7 @@ export function SearchSheet() {
   return (
     <Sheet>
       <SheetTrigger asChild>
-        <Button variant="outline" size="icon" disabled={!currentFile}>
+        <Button variant="outline" size="icon">
           <TelescopeIcon className="size-4" />
         </Button>
       </SheetTrigger>

--- a/components/sidebar/createPageButton.tsx
+++ b/components/sidebar/createPageButton.tsx
@@ -29,7 +29,6 @@ export default function CreatePageButton() {
       variant="outline"
       disabled={!currentFolder || !currentFile || isLoading}
       onClick={handleCreateFile}
-      className="w-full"
     >
       <PlusIcon />
       New Page

--- a/components/sidebar/currentFolder.tsx
+++ b/components/sidebar/currentFolder.tsx
@@ -128,7 +128,9 @@ export default function CurrentFolder() {
             </AccordionContent>
           </AccordionItem>
         </Accordion>
-        <CreatePageButton />
+        <div className="flex justify-end">
+          <CreatePageButton />
+        </div>
       </SidebarGroupContent>
     </SidebarGroup>
   );

--- a/components/sidebar/newFolderDialog.tsx
+++ b/components/sidebar/newFolderDialog.tsx
@@ -37,7 +37,7 @@ export default function NewFolderDialog() {
   return (
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger asChild>
-        <Button size="sm" className="w-full">
+        <Button size="sm">
           <Plus className="w-4 h-4 mr-2" />
           New Folder
         </Button>

--- a/components/sidebar/sidebar.tsx
+++ b/components/sidebar/sidebar.tsx
@@ -23,7 +23,9 @@ export async function DashboardSidebar() {
         <Folders folders={folders} />
         <SidebarGroup>
           <SidebarGroupContent>
-            <NewFolderDialog />
+            <div className="flex justify-end">
+              <NewFolderDialog />
+            </div>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>


### PR DESCRIPTION
## Summary
- Allow opening the search sheet even when no file is selected
- Right-align sidebar "New Folder" and "New Page" buttons without styling group container
- Remove background styling from AI chat messages

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68bca9aeb6a48324a18ab9f01814d777