### PR TITLE
feat: add loading indicators to file actions

### DIFF
--- a/components/sidebar/createPageButton.tsx
+++ b/components/sidebar/createPageButton.tsx
@@ -2,7 +2,7 @@
 
 import { useSidebarStore } from "@/store/sidebar";
 import { Button } from "../ui/button";
-import { PlusIcon } from "lucide-react";
+import { Loader2Icon, PlusIcon } from "lucide-react";
 import { createFileAfterCurrentAction } from "@/app/(main)/dashboard/actions";
 import { useDashboardStore } from "@/store/dashboard";
 
@@ -30,7 +30,11 @@ export default function CreatePageButton() {
       disabled={!currentFolder || !currentFile || isLoading}
       onClick={handleCreateFile}
     >
-      <PlusIcon />
+      {isLoading ? (
+        <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+      ) : (
+        <PlusIcon />
+      )}
       New Page
     </Button>
   );

--- a/components/sidebar/currentFolder.tsx
+++ b/components/sidebar/currentFolder.tsx
@@ -29,7 +29,7 @@ import CreatePageButton from "./createPageButton";
 export default function CurrentFolder() {
   const { currentFolder, currentFiles, setCurrentFiles, setIsDeleting } =
     useSidebarStore();
-  const { setCurrentFile } = useDashboardStore();
+  const { currentFile, setCurrentFile } = useDashboardStore();
 
   const handleDeleteFile = async (fileId: number) => {
     if (!currentFolder) return;
@@ -54,6 +54,12 @@ export default function CurrentFolder() {
       const file = await createFileAction(currentFolder.id, 0);
       setCurrentFiles([file]);
       setCurrentFile(file);
+    } else {
+      const updatedCurrent =
+        currentFile?.id === fileId
+          ? filteredFiles[0]
+          : filteredFiles.find((file) => file.id === currentFile?.id);
+      if (updatedCurrent) setCurrentFile(updatedCurrent);
     }
     setIsDeleting(false);
   };

--- a/components/sidebar/deleteConfirmationDialog.tsx
+++ b/components/sidebar/deleteConfirmationDialog.tsx
@@ -10,7 +10,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { Trash2Icon } from "lucide-react";
+import { Loader2Icon, Trash2Icon } from "lucide-react";
 import { useSidebarStore } from "@/store/sidebar";
 
 export default function DeleteConfirmationDialog({
@@ -24,8 +24,17 @@ export default function DeleteConfirmationDialog({
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant="ghost" size="icon" className="text-destructive">
-          <Trash2Icon className="w-4 h-4" />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-destructive"
+          disabled={isDeleting}
+        >
+          {isDeleting ? (
+            <Loader2Icon className="w-4 h-4 animate-spin" />
+          ) : (
+            <Trash2Icon className="w-4 h-4" />
+          )}
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
@@ -40,7 +49,11 @@ export default function DeleteConfirmationDialog({
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction onClick={deleteFunction} disabled={isDeleting}>
-            Delete
+            {isDeleting ? (
+              <Loader2Icon className="w-4 h-4 animate-spin" />
+            ) : (
+              "Delete"
+            )}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/components/sidebar/newFolderDialog.tsx
+++ b/components/sidebar/newFolderDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
-import { PlusIcon } from "lucide-react";
+import { Loader2Icon, PlusIcon } from "lucide-react";
 import { useSidebarStore } from "@/store/sidebar";
 import { createFolderAction } from "@/app/(main)/dashboard/actions";
 
@@ -37,8 +37,12 @@ export default function NewFolderDialog() {
   return (
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger asChild>
-        <Button size="sm">
-          <PlusIcon />
+        <Button size="sm" disabled={isCreatingFolder}>
+          {isCreatingFolder ? (
+            <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <PlusIcon />
+          )}
           New Folder
         </Button>
       </DialogTrigger>
@@ -62,6 +66,9 @@ export default function NewFolderDialog() {
             disabled={newFolderName === "" || !isDialogOpen || isCreatingFolder}
             onClick={handleCreateFolder}
           >
+            {isCreatingFolder ? (
+              <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             Create
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## Summary
- update current file after deleting a file
- show loading indicators on delete, new page, and folder creation buttons

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68be0e0c61c48324bb6d46a3f9e4a184