### PR TITLE
feat: add loading indicators to file actions

### DIFF
--- a/components/sidebar/createPageButton.tsx
+++ b/components/sidebar/createPageButton.tsx
@@ -2,7 +2,7 @@
 
 import { useSidebarStore } from "@/store/sidebar";
 import { Button } from "../ui/button";
-import { PlusIcon } from "lucide-react";
+import { Loader2Icon, PlusIcon } from "lucide-react";
 import { createFileAfterCurrentAction } from "@/app/(main)/dashboard/actions";
 import { useDashboardStore } from "@/store/dashboard";
 
@@ -30,7 +30,11 @@ export default function CreatePageButton() {
       disabled={!currentFolder || !currentFile || isLoading}
       onClick={handleCreateFile}
     >
-      <PlusIcon />
+      {isLoading ? (
+        <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+      ) : (
+        <PlusIcon />
+      )}
       New Page
     </Button>
   );

--- a/components/sidebar/currentFolder.tsx
+++ b/components/sidebar/currentFolder.tsx
@@ -15,11 +15,13 @@ import { CheckIcon, Folder, PencilIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { useSidebarStore } from "@/store/sidebar";
 import { useDashboardStore } from "@/store/dashboard";
+import { useRouter } from "next/navigation";
 import {
   deleteFolderAction,
   deleteFileAction,
   updateFolderAction,
   createFileAction,
+  readFoldersAction,
 } from "@/app/(main)/dashboard/actions";
 import { Input } from "../ui/input";
 import { UsedFolder } from "@/store/sidebar";
@@ -27,9 +29,8 @@ import DeleteConfirmationDialog from "./deleteConfirmationDialog";
 import CreatePageButton from "./createPageButton";
 
 export default function CurrentFolder() {
-  const { currentFolder, currentFiles, setCurrentFiles, setIsDeleting } =
-    useSidebarStore();
-  const { setCurrentFile } = useDashboardStore();
+  const { currentFolder, currentFiles, setCurrentFiles } = useSidebarStore();
+  const { currentFile, setCurrentFile } = useDashboardStore();
 
   const handleDeleteFile = async (fileId: number) => {
     if (!currentFolder) return;
@@ -37,7 +38,6 @@ export default function CurrentFolder() {
     const fileToDelete = currentFiles.find((file) => file.id === fileId);
     if (!fileToDelete) return;
 
-    setIsDeleting(true);
     await deleteFileAction(fileId, currentFolder.id, fileToDelete.page);
 
     const filteredFiles = currentFiles
@@ -54,8 +54,13 @@ export default function CurrentFolder() {
       const file = await createFileAction(currentFolder.id, 0);
       setCurrentFiles([file]);
       setCurrentFile(file);
+    } else {
+      const updatedCurrent =
+        currentFile?.id === fileId
+          ? filteredFiles[0]
+          : filteredFiles.find((file) => file.id === currentFile?.id);
+      if (updatedCurrent) setCurrentFile(updatedCurrent);
     }
-    setIsDeleting(false);
   };
 
   if (!currentFolder)
@@ -128,8 +133,15 @@ export default function CurrentFolder() {
 }
 
 function EditFolder({ currentFolder }: { currentFolder: UsedFolder }) {
-  const { isEditingFolder, setIsEditingFolder, setCurrentFolder } =
-    useSidebarStore();
+  const {
+    isEditingFolder,
+    setIsEditingFolder,
+    setCurrentFolder,
+    setCurrentFiles,
+    cacheFiles,
+  } = useSidebarStore();
+  const { setCurrentFile } = useDashboardStore();
+  const router = useRouter();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setCurrentFolder({ ...currentFolder, name: e.target.value });
@@ -142,9 +154,23 @@ function EditFolder({ currentFolder }: { currentFolder: UsedFolder }) {
     setIsEditingFolder(!isEditingFolder);
   };
 
-  const handleDeleteFolder = () => {
-    deleteFolderAction(currentFolder.id);
-    setCurrentFolder(undefined);
+  const handleDeleteFolder = async () => {
+    await deleteFolderAction(currentFolder.id);
+
+    const folders = await readFoldersAction();
+    if (folders.length > 0) {
+      const first = folders[0];
+      setCurrentFolder(first);
+      cacheFiles(first.id, first.files);
+      setCurrentFiles(first.files);
+      setCurrentFile(first.files[0] ?? undefined);
+    } else {
+      setCurrentFolder(undefined);
+      setCurrentFiles([]);
+      setCurrentFile(undefined);
+    }
+
+    router.refresh();
   };
 
   return (

--- a/components/sidebar/deleteConfirmationDialog.tsx
+++ b/components/sidebar/deleteConfirmationDialog.tsx
@@ -10,22 +10,37 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
-import { Trash2Icon } from "lucide-react";
-import { useSidebarStore } from "@/store/sidebar";
+import { Loader2Icon, Trash2Icon } from "lucide-react";
+import { useState } from "react";
 
 export default function DeleteConfirmationDialog({
   deleteFunction,
   target,
 }: {
-  deleteFunction: () => void;
+  deleteFunction: () => Promise<void>;
   target: string;
 }) {
-  const { isDeleting } = useSidebarStore();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    await deleteFunction();
+    setIsDeleting(false);
+  };
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant="ghost" size="icon" className="text-destructive">
-          <Trash2Icon className="w-4 h-4" />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-destructive"
+          disabled={isDeleting}
+        >
+          {isDeleting ? (
+            <Loader2Icon className="w-4 h-4 animate-spin" />
+          ) : (
+            <Trash2Icon className="w-4 h-4" />
+          )}
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
@@ -39,8 +54,12 @@ export default function DeleteConfirmationDialog({
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={deleteFunction} disabled={isDeleting}>
-            Delete
+          <AlertDialogAction onClick={handleDelete} disabled={isDeleting}>
+            {isDeleting ? (
+              <Loader2Icon className="w-4 h-4 animate-spin" />
+            ) : (
+              "Delete"
+            )}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/components/sidebar/newFolderDialog.tsx
+++ b/components/sidebar/newFolderDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
-import { PlusIcon } from "lucide-react";
+import { Loader2Icon, PlusIcon } from "lucide-react";
 import { useSidebarStore } from "@/store/sidebar";
 import { createFolderAction } from "@/app/(main)/dashboard/actions";
 
@@ -37,8 +37,12 @@ export default function NewFolderDialog() {
   return (
     <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <DialogTrigger asChild>
-        <Button size="sm">
-          <PlusIcon />
+        <Button size="sm" disabled={isCreatingFolder}>
+          {isCreatingFolder ? (
+            <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <PlusIcon />
+          )}
           New Folder
         </Button>
       </DialogTrigger>
@@ -62,6 +66,9 @@ export default function NewFolderDialog() {
             disabled={newFolderName === "" || !isDialogOpen || isCreatingFolder}
             onClick={handleCreateFolder}
           >
+            {isCreatingFolder ? (
+              <Loader2Icon className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
             Create
           </Button>
         </DialogFooter>

--- a/store/sidebar.ts
+++ b/store/sidebar.ts
@@ -41,9 +41,6 @@ interface SidebarState {
 
   isCreatingFolder: boolean;
   setIsCreatingFolder: (isCreatingFolder: boolean) => void;
-
-  isDeleting: boolean;
-  setIsDeleting: (isDeletingFile: boolean) => void;
   getFilesByFolder: (folderId: number) => UsedFile[];
 }
 
@@ -117,9 +114,6 @@ export const useSidebarStore = create<SidebarState>((set, get) => ({
 
   isCreatingFolder: false,
   setIsCreatingFolder: (isCreatingFolder) => set({ isCreatingFolder }),
-
-  isDeleting: false,
-  setIsDeleting: (isDeleting) => set({ isDeleting }),
 
   filesCache: {},
   cacheFiles: (folderId, files) =>


### PR DESCRIPTION
## Summary
- update current file after deleting a file
- show loading indicators on delete, new page, and folder creation buttons
- manage delete button loading per-instance and refresh folder list after folder removal
- reset current folder and file to first available after folder deletion

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68be0e0c61c48324bb6d46a3f9e4a184