### PR TITLE
feat: improve auth loading and signup notice

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -11,7 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ArrowLeftIcon } from "lucide-react";
+import { ArrowLeftIcon, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { useAuthStore } from "@/store/auth";
 import { PRODUCT_NAME } from "@/constants";
@@ -66,6 +66,9 @@ export default function Login() {
               onClick={handleLogin}
               disabled={isLoading}
             >
+              {isLoading && (
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              )}
               Login
             </Button>
           </CardAction>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -11,8 +11,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ArrowLeftIcon } from "lucide-react";
+import { ArrowLeftIcon, Loader2 } from "lucide-react";
 import Link from "next/link";
+import { toast } from "sonner";
 import { useAuthStore } from "@/store/auth";
 import { PRODUCT_NAME } from "@/constants";
 import { signup } from "@/lib/auth/signup";
@@ -23,7 +24,13 @@ export default function Signup() {
 
   const handleSignup = async () => {
     await setIsLoading(true);
-    await signup(email, password);
+    const { error } = await signup(email, password);
+    await setIsLoading(false);
+    if (!error) {
+      toast("Check your email", {
+        description: "A confirmation link has been sent to your inbox",
+      });
+    }
   };
 
   return (
@@ -66,6 +73,9 @@ export default function Signup() {
               onClick={handleSignup}
               disabled={isLoading}
             >
+              {isLoading && (
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              )}
               Signup
             </Button>
           </CardAction>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
+import { Toaster } from "sonner";
 import { PRODUCT_NAME, PRODUCT_DESCRIPTION } from "@/constants/index";
 
 const inter = Inter({
@@ -29,6 +30,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           {children}
+          <Toaster />
         </ThemeProvider>
       </body>
     </html>

--- a/lib/auth/signup.ts
+++ b/lib/auth/signup.ts
@@ -1,8 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
-
 import { createClient } from "@/utils/supabase/server";
 
 export async function signup(email: string, password: string) {
@@ -19,9 +16,7 @@ export async function signup(email: string, password: string) {
 
   if (error) {
     console.error(error);
-    redirect("/error");
   }
 
-  revalidatePath("/", "layout");
-  redirect("/dashboard");
+  return { error };
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
+    "sonner": "^1.5.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^4.0.14",
     "zustand": "^5.0.7"

--- a/types/sonner.d.ts
+++ b/types/sonner.d.ts
@@ -1,0 +1,1 @@
+declare module "sonner";


### PR DESCRIPTION
## Summary
- show Loader2 spinner on login and signup buttons
- notify users to check email after signup with sonner toast
- expose Toaster and adjust signup server action for client-side handling

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68be1b74eda48324910abd78017b00aa