### PR TITLE
Remove 30s streaming response cap

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,9 +1,6 @@
 import { openai } from "@ai-sdk/openai";
 import { streamText, UIMessage, convertToModelMessages } from "ai";
 
-// Allow streaming responses up to 30 seconds
-export const maxDuration = 30;
-
 export async function POST(req: Request) {
   const { messages, model }: { messages: UIMessage[]; model?: string } =
     await req.json();


### PR DESCRIPTION
## Summary
- allow streaming chat responses longer than 30 seconds by removing `maxDuration` limit

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68be7a86768c8324a7361da211fb1bcf