### PR TITLE
fix: remove model selection and use default model

### DIFF
--- a/app/(main)/search/page.tsx
+++ b/app/(main)/search/page.tsx
@@ -2,20 +2,12 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Loader2Icon } from "lucide-react";
 import { SearchIcon } from "lucide-react";
 import { useChatStore } from "@/store/chat";
 import { Message } from "@/components/chat/message";
 import { useChat } from "@ai-sdk/react";
 import { UIMessage } from "ai";
-import { models } from "@/store/chat";
 import { useEffect, useRef } from "react";
 import Link from "next/link";
 import { saveMessageAction, readMessagesAction } from "./actions";
@@ -33,8 +25,6 @@ export default function SearchPage() {
   const {
     input,
     setInput,
-    selectedModel,
-    setSelectedModel,
     isSending,
     setIsSending,
   } = useChatStore();
@@ -114,18 +104,6 @@ export default function SearchPage() {
           >
             Clear Chat
           </Button>
-          <Select value={selectedModel} onValueChange={setSelectedModel}>
-            <SelectTrigger className="w-[180px]">
-              <SelectValue placeholder="Model" />
-            </SelectTrigger>
-            <SelectContent>
-              {models.map((model) => (
-                <SelectItem key={model} value={model}>
-                  {model}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
         </div>
       </div>
       <div className="flex flex-col gap-4 px-4 overflow-y-auto h-full">
@@ -152,10 +130,7 @@ export default function SearchPage() {
                 "user",
               );
               setCurrentConversationId(returnConversationId);
-              await sendMessage(
-                { text: sendInput },
-                { body: { model: selectedModel } },
-              );
+              await sendMessage({ text: sendInput });
             } finally {
               setIsSending(false);
             }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,11 +2,10 @@ import { openai } from "@ai-sdk/openai";
 import { streamText, UIMessage, convertToModelMessages } from "ai";
 
 export async function POST(req: Request) {
-  const { messages, model }: { messages: UIMessage[]; model?: string } =
-    await req.json();
+  const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai(model ?? "gpt-5-nano"),
+    model: openai("gpt-5-nano"),
     messages: convertToModelMessages(messages),
     tools: {
       web_search_preview: openai.tools.webSearchPreview({

--- a/store/chat.ts
+++ b/store/chat.ts
@@ -4,19 +4,6 @@ export interface Message {
   role: "user" | "assistant" | "developer";
   content: string;
 }
-
-export const models = [
-  "gpt-5-nano",
-  "gpt-5-mini",
-  "gpt-5",
-  "o4-mini-deep-research",
-  "gpt-oss-20b",
-  "gpt-oss-120b",
-  "gpt-4.1",
-  "gpt-5-chat-latest",
-  "chatgpt-4o-latest",
-];
-type Model = (typeof models)[number];
 export interface UIMessage {
   id: string;
   content: string;
@@ -41,9 +28,6 @@ interface ChatStore {
 
   isIncludeContext: boolean;
   setIsIncludeContext: (isIncludeContext: boolean) => void;
-
-  selectedModel: Model;
-  setSelectedModel: (selectedModel: Model) => void;
 
   currentConversationId: number | null;
   setCurrentConversationId: (id: number | null) => void;
@@ -70,8 +54,6 @@ export const useChatStore = create<ChatStore>((set) => ({
 
   isIncludeContext: false,
   setIsIncludeContext: (isIncludeContext) => set({ isIncludeContext }),
-  selectedModel: models[0],
-  setSelectedModel: (selectedModel: Model) => set({ selectedModel }),
 
   currentConversationId: null,
   setCurrentConversationId: (id: number | null) =>


### PR DESCRIPTION
## Summary
- remove model list and selection state from chat store
- drop model dropdown and always send messages with default model
- fix chat API to always call `gpt-5-nano`

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc032918c8324bba6a95dfad7b40b