### PR TITLE
fix: remove model selection and use default model

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,11 +2,10 @@ import { openai } from "@ai-sdk/openai";
 import { streamText, UIMessage, convertToModelMessages } from "ai";
 
 export async function POST(req: Request) {
-  const { messages, model }: { messages: UIMessage[]; model?: string } =
-    await req.json();
+  const { messages }: { messages: UIMessage[] } = await req.json();
 
   const result = streamText({
-    model: openai(model ?? "gpt-5-nano"),
+    model: openai("gpt-5-nano"),
     messages: convertToModelMessages(messages),
     tools: {
       web_search_preview: openai.tools.webSearchPreview({

--- a/store/chat.ts
+++ b/store/chat.ts
@@ -4,19 +4,6 @@ export interface Message {
   role: "user" | "assistant" | "developer";
   content: string;
 }
-
-export const models = [
-  "gpt-5-nano",
-  "gpt-5-mini",
-  "gpt-5",
-  "o4-mini-deep-research",
-  "gpt-oss-20b",
-  "gpt-oss-120b",
-  "gpt-4.1",
-  "gpt-5-chat-latest",
-  "chatgpt-4o-latest",
-];
-type Model = (typeof models)[number];
 export interface UIMessage {
   id: string;
   content: string;
@@ -41,9 +28,6 @@ interface ChatStore {
 
   isIncludeContext: boolean;
   setIsIncludeContext: (isIncludeContext: boolean) => void;
-
-  selectedModel: Model;
-  setSelectedModel: (selectedModel: Model) => void;
 
   currentConversationId: number | null;
   setCurrentConversationId: (id: number | null) => void;
@@ -70,8 +54,6 @@ export const useChatStore = create<ChatStore>((set) => ({
 
   isIncludeContext: false,
   setIsIncludeContext: (isIncludeContext) => set({ isIncludeContext }),
-  selectedModel: models[0],
-  setSelectedModel: (selectedModel: Model) => set({ selectedModel }),
 
   currentConversationId: null,
   setCurrentConversationId: (id: number | null) =>


### PR DESCRIPTION
## Summary
- remove model list and selection state from chat store
- drop model dropdown and always send messages with default model
- fix chat API to always call `gpt-5-nano`
- use `DefaultChatTransport` to send requests to `/api/chat`

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc032918c8324bba6a95dfad7b40b