### PR TITLE
Fix AI message width overflow

### DIFF
--- a/components/chat/message.tsx
+++ b/components/chat/message.tsx
@@ -18,20 +18,26 @@ export function Message({
     <div className={cn("flex flex-row gap-2 items-end", !isUser && "w-full")}>
       <div
         className={cn(
-          "flex flex-col gap-2 text-sm",
-          isUser &&
-            "rounded-lg px-3 py-2 bg-primary text-primary-foreground ml-auto w-max max-w-[75%]",
+          "flex flex-col gap-2 text-sm break-words",
+          isUser
+            ? "rounded-lg px-3 py-2 bg-primary text-primary-foreground ml-auto w-max max-w-[75%]"
+            : "max-w-prose w-full",
         )}
       >
         {parts.map((part: UIMessage["parts"][number], i: number) => {
           switch (part.type) {
             case "text": {
               if (isUser) {
-                return <div key={`${i}`}>{part.text}</div>;
+                return (
+                  <div key={`${i}`} className="whitespace-pre-wrap">
+                    {part.text}
+                  </div>
+                );
               }
               return (
                 <ReactMarkdown
                   key={`${i}`}
+                  className="break-words whitespace-pre-wrap"
                   remarkPlugins={[remarkGfm]}
                   rehypePlugins={[rehypeRaw]}
                   components={markdownComponents}


### PR DESCRIPTION
## Summary
- limit assistant chat messages to a prose-sized width so they no longer overflow
- preserve line breaks and enable word-wrapping for user and markdown responses

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c9ca4051c8832495e4fc2e094a3807