### PR TITLE
Improve route loading experience with suspense skeletons

### DIFF
--- a/app/(main)/search/layout.tsx
+++ b/app/(main)/search/layout.tsx
@@ -1,12 +1,17 @@
+import { Suspense } from "react";
+import type { ReactNode } from "react";
 import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
 import { SearchSidebar } from "@/components/searchSidebar/sidebar";
+import { SearchSidebarSkeleton } from "@/components/searchSidebar/sidebar-skeleton";
 
 export const dynamic = "force-dynamic";
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({ children }: { children: ReactNode }) {
   return (
     <SidebarProvider>
-      <SearchSidebar />
+      <Suspense fallback={<SearchSidebarSkeleton />}>
+        <SearchSidebar />
+      </Suspense>
       <main className="w-full">
         <SidebarTrigger />
         {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { Suspense } from "react";
+import type { ReactNode } from "react";
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "sonner";
 import { PRODUCT_NAME, PRODUCT_DESCRIPTION } from "@/constants/index";
+import { AppPageLoading } from "@/components/loading/app-page-loading";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -18,7 +21,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -29,7 +32,9 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          {children}
+          <Suspense fallback={<AppPageLoading />}>
+            {children}
+          </Suspense>
           <Toaster />
         </ThemeProvider>
       </body>

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,9 +1,5 @@
-import { Loader2Icon } from "lucide-react";
+import { AppPageLoading } from "@/components/loading/app-page-loading";
 
 export default function Loading() {
-  return (
-    <div className="flex flex-col items-center justify-center h-[100dvh] p-4">
-      <Loader2Icon className="animate-spin size-8 text-primary" />
-    </div>
-  );
+  return <AppPageLoading />;
 }

--- a/components/loading/app-page-loading.tsx
+++ b/components/loading/app-page-loading.tsx
@@ -1,0 +1,47 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function AppPageLoading() {
+  return (
+    <div
+      aria-busy
+      aria-live="polite"
+      className="flex min-h-screen flex-col bg-background"
+    >
+      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10">
+        <header className="flex flex-col gap-4">
+          <div className="flex items-center justify-between gap-6">
+            <Skeleton className="h-10 w-32" />
+            <div className="flex items-center gap-3">
+              <Skeleton className="h-9 w-9 rounded-full" />
+              <Skeleton className="h-9 w-24" />
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Skeleton className="h-8 w-28" />
+            <Skeleton className="h-8 w-20" />
+            <Skeleton className="h-8 w-24" />
+          </div>
+        </header>
+
+        <div className="grid flex-1 grid-cols-1 gap-6 md:grid-cols-[240px_1fr]">
+          <aside className="hidden flex-col gap-3 md:flex">
+            <Skeleton className="h-6 w-32" />
+            <div className="space-y-3">
+              <Skeleton className="h-9 w-full" />
+              <Skeleton className="h-9 w-full" />
+              <Skeleton className="h-9 w-full" />
+            </div>
+          </aside>
+          <section className="flex flex-1 flex-col gap-4">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-[40vh] w-full" />
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <Skeleton className="h-28 w-full" />
+              <Skeleton className="h-28 w-full" />
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/searchSidebar/sidebar-skeleton.tsx
+++ b/components/searchSidebar/sidebar-skeleton.tsx
@@ -1,0 +1,31 @@
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuSkeleton,
+} from "@/components/ui/sidebar";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function SearchSidebarSkeleton() {
+  return (
+    <Sidebar>
+      <SidebarHeader>
+        <Skeleton className="h-9 w-9 rounded-full" />
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {Array.from({ length: 6 }).map((_, index) => (
+                <SidebarMenuSkeleton key={index} showIcon />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  );
+}


### PR DESCRIPTION
## Summary
- add a shared AppPageLoading skeleton and reuse it for the global loading state
- wrap the root layout in Suspense to display the skeleton during route transitions
- provide a Suspense boundary for the search sidebar with a matching skeleton fallback

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cac3fda5a48324babaf800bd3819b5